### PR TITLE
mousedown hijack fix for error/help dialogs

### DIFF
--- a/js/fc/ui/relocator.js
+++ b/js/fc/ui/relocator.js
@@ -20,7 +20,7 @@ define(function() {
         // move the message to this line
         var _tmp = element.clone();
         element.replaceWith(_tmp);
-        $(".CodeMirror-lines").append(element);
+        $(".CodeMirror-scroll").append(element);
         _tmp.remove();
         
         // set the correct "top" value, making sure to place the element

--- a/js/main.js
+++ b/js/main.js
@@ -128,6 +128,18 @@ define("main", function(require) {
       hints.removeClass("off").addClass("on");
     }
   });
+
+  // prevent CodeMirror for hijacking clicks on the help and error notices
+  $("div.help, div.error").each(function(){
+    this.onmousedown = function(event) {
+      if (event.cancelBubble) {
+        event.cancelBubble = true;
+      } else if (event.stopPropagation) {
+        event.stopPropagation();
+      }
+      return false;
+    };
+  });
   
   // TEMP TEMP TEMP TEMP TEMP -- HOOK UP VIA publishUI INSTEAD
   $("#publish-button").click(function(){


### PR DESCRIPTION
fixed error/help from being mouse-hijacked by codemirror. click events on it are now cut off so that codemirror can't reposition the cursor, force a update, and remove the hint based on the new cursor position
