### PR TITLE
fixed up issue 251

### DIFF
--- a/css/jsbin-codemirror-theme.css
+++ b/css/jsbin-codemirror-theme.css
@@ -28,13 +28,13 @@
   font-family: "Myriad Pro", "myriad-pro", Helvetica, Arial, sans-serif;
   color: #333;
   font-size: 14px;
-  line-height: 16px;
+  line-height: 15.75px;
 }
 
 .CodeMirror textarea {
   font-family: "Myriad Pro", "myriad-pro", Helvetica, Arial, sans-serif;
   font-size: 14px;
-  line-height: 16px;
+  line-height: 15.75px;
 }
 
 .CodeMirror-gutter {
@@ -46,7 +46,7 @@
   font-family: Menlo, Monaco, consolas, monospace;
   color: #A9A9A9;
   font-size: 12px;
-  line-height: 18px;
+  line-height: 15.75px;
 }
 
 .cm-s-jsbin span.cm-meta {
@@ -58,8 +58,7 @@
   color: #333;
   font-style: italic;
   font-weight: bold;
-  font-size: 14px;
-  line-height: 15px; /* needs to be a little less than the standard line-height to align on multi-line wrapped content */
+  line-height: 15.75px; /* needs to be a little less than the standard line-height to align on multi-line wrapped content */
 }
 
 .CodeMirror span.cursor-help-highlight,

--- a/js/fc/ui/text.js
+++ b/js/fc/ui/text.js
@@ -98,11 +98,10 @@ define(function() {
      * If there is a thimble text size set, trigger it.
      */
     if (supportsLocalStorage()) {
-      var textSize = "normal";
       if (typeof localStorage["ThimbleTextSize"] !== "undefined") {
-        textSize = localStorage["ThimbleTextSize"];
+        var textSize = localStorage["ThimbleTextSize"];
+        $("#text-nav-item li[data-size="+textSize+"]").click();
       }
-      $("#text-nav-item li[data-size="+textSize+"]").click();
     }
   };
 });


### PR DESCRIPTION
made default view the same as 'normal' text size. Updated text size change to only occur if localStorage has a text size entry instead of also trying to trigger 'normal' in the absence of a localStorage value
