### PR TITLE
Use protocol-relative urls for external resources.

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,11 +168,10 @@
     <script data-main="js/main" src="js/require.min.js"></script>
 
     <!-- this COULD hold up the page, so do this absolutely last -->
-    <script type="text/javascript" src="http://use.typekit.com/qjh6hdg.js"></script>
+    <script type="text/javascript" src="//use.typekit.com/qjh6hdg.js"></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-    <link rel="stylesheet" href="http://www.mozilla.org/tabzilla/media/css/tabzilla.css">
+    <link rel="stylesheet" href="//www.mozilla.org/tabzilla/media/css/tabzilla.css">
     <link rel="stylesheet" href="css/tabzilla-overrides.css">
-    <script src="http://www.mozilla.org/tabzilla/media/js/tabzilla.js"></script>
-
+    <script src="//www.mozilla.org/tabzilla/media/js/tabzilla.js"></script>
   </body>
 </html>


### PR DESCRIPTION
(addresses issue #77, tracking #wpm/301)

We need to use protocol relative URLs for our external resources so
browsers don't complain that we're serving mixed content. This will
fix the problem by serving the secure resource only when needed.

@toolness: R?
