### PR TITLE
Backbonify preferences

### DIFF
--- a/js/fc/prefs.js
+++ b/js/fc/prefs.js
@@ -1,0 +1,29 @@
+define(["backbone", "lscache"], function(Backbone, lscache) {
+  
+  var Preferences = Backbone.Model.extend({
+    // Amount of time, in minutes, to store text size setting.
+    CACHE_TIME_LIMIT: 9000,
+    // Key to store our Preferences JSON blob in.
+    CACHE_KEY: 'FriendlycodePreferences',
+    // Used so that Model.isNew() is always false.
+    id: 1,
+    sync: function(method, model, options) {
+      var json;
+      
+      if (method == "create" || method == "update") {
+        json = model.toJSON();
+        lscache.set(this.CACHE_KEY, json, this.CACHE_TIME_LIMIT);
+        options.success(json);
+      } else if (method == "delete") {
+        lscache.remove(this.CACHE_KEY);
+      } else if (method == "read") {
+        json = lscache.get(this.CACHE_KEY);
+        if (!json || typeof(json) != "object")
+          json = {};
+        options.success(json);
+      }
+    }
+  });
+  
+  return new Preferences();
+});

--- a/js/fc/ui/context-sensitive-help.js
+++ b/js/fc/ui/context-sensitive-help.js
@@ -4,10 +4,9 @@
 // the current cursor position.
 define([
   "jquery",
-  "underscore",
-  "backbone",
+  "fc/prefs",
   "./mark-tracker"
-], function($, _, Backbone, MarkTracker) {
+], function($, Preferences, MarkTracker) {
   return function ContextSensitiveHelp(options) {
     var self = {};
     var codeMirror = options.codeMirror;
@@ -18,7 +17,6 @@ define([
     var lastEvent = null;
     var timeout = null;
     var lastHelp = null;
-    var isEnabled = true;
     var HELP_DISPLAY_DELAY = 250;
     
     // The escape key should close hints 
@@ -84,7 +82,7 @@ define([
     codeMirror.on("cursor-activity", function() {
       clearTimeout(timeout);
       
-      if (!isEnabled)
+      if (Preferences.get("showHints") === false)
         return;
 
       // If the editor widget doesn't have input focus, this event
@@ -109,25 +107,12 @@ define([
       }
     });
 
-    self.isEnabled = function() {
-      return isEnabled;
-    };
+    Preferences.on("change:showHints", function() {
+      if (Preferences.get("showHints") === false)
+        clearHelp();
+    });
     
-    self.setEnabled = function(value) {
-      if (isEnabled != value) {
-        isEnabled = value;
-        if (!isEnabled)
-          clearHelp();
-        self.trigger("set-enabled", isEnabled);
-      }
-    };
-    
-    self.toggleEnabled = function() {
-      self.setEnabled(!isEnabled);
-    };
-    
-    _.extend(self, Backbone.Events);
-    
+    Preferences.trigger("change:showHints");
     return self;
   };
 });

--- a/js/fc/ui/editor-toolbar.js
+++ b/js/fc/ui/editor-toolbar.js
@@ -1,26 +1,29 @@
 define(function(require) {
   var $ = require("jquery-tipsy"),
+      Preferences = require("fc/prefs"),
       HistoryUI = require("fc/ui/history"),
       NavOptionsTemplate = require("template!nav-options"),
       TextUI = require("fc/ui/text");
   
   function HintsUI(options) {
     var self = {},
-        cursorHelp = options.cursorHelp,
         hintsNavItem = options.navItem,
         hintsCheckbox = hintsNavItem.find(".checkbox");
     
-    function onChange() {
-      if (!this.isEnabled())
+    Preferences.on("change:showHints", function() {
+      if (Preferences.get("showHints") === false)
         hintsCheckbox.removeClass("on").addClass("off");
       else
         hintsCheckbox.removeClass("off").addClass("on");
-    }
+    });
     
-    cursorHelp.on("set-enabled", onChange);
-    hintsNavItem.click(function() { cursorHelp.toggleEnabled(); });
-    onChange.call(cursorHelp);
+    hintsNavItem.click(function() {
+      var isDisabled = (Preferences.get("showHints") === false);
+      Preferences.set("showHints", isDisabled);
+      Preferences.save();
+    });
 
+    Preferences.trigger("change:showHints");
     return self;
   }
   
@@ -43,7 +46,6 @@ define(function(require) {
       navItem: navOptions.find(".text-nav-item")
     });
     var hintsUI = HintsUI({
-      cursorHelp: editor.cursorHelp,
       navItem: navOptions.find(".hints-nav-item")
     });
     

--- a/js/fc/ui/text.js
+++ b/js/fc/ui/text.js
@@ -1,14 +1,9 @@
 "use strict";
 
-define(["jquery", "lscache"], function($, lscache) {
-  // Amount of time, in minutes, to store text size setting.
-  var CACHE_TIME_LIMIT = 9000;
-  var DEFAULT_CACHE_KEY = "ThimbleTextSize";
-
+define(["jquery", "fc/prefs"], function($, Preferences) {
   return function(options) {
     var codeMirror = options.codeMirror;
     var navItem = options.navItem;
-    var cacheKey = options.cacheKey || DEFAULT_CACHE_KEY;
     var menu = navItem.find("ul");
     var menuItems = menu.find("li");
     
@@ -17,6 +12,23 @@ define(["jquery", "lscache"], function($, lscache) {
       return item.length ? item : null;
     }
     
+    Preferences.on("change:textSize", function() {
+      var size = $("li[data-default-size]", menu).attr("data-size");
+      var prefSize = Preferences.get("textSize");
+      if (prefSize && typeof(prefSize) == "string" && menuItem(prefSize))
+        size = prefSize;
+      
+      $(codeMirror.getWrapperElement()).attr("data-size", size);
+      codeMirror.refresh();
+
+      // Reparse as well, in case there were any errors.
+      codeMirror.reparse();
+
+      // Mark text size in drop-down.
+      menuItems.removeClass("selected");
+      menuItem(size).addClass("selected");
+    });
+
     /**
      * Show or hide the font size drop-down menu
      */
@@ -34,27 +46,11 @@ define(["jquery", "lscache"], function($, lscache) {
      * bind the resize behaviour to the various text resize options
      */
     menuItems.click(function() {
-      var t = $(this),
-          size = t.attr("data-size");
-      
-      $(codeMirror.getWrapperElement()).attr("data-size", size);
-      
-      // refesh code mirror
-      codeMirror.refresh();
-      // reparse as well, in case there were any errors
-      codeMirror.reparse();
-      lscache.set(cacheKey, size, CACHE_TIME_LIMIT);
-      // mark text size in drop-down
-      menuItems.removeClass("selected");
-      $(this).addClass("selected");
+      Preferences.set("textSize", $(this).attr("data-size"));
+      Preferences.save();
       menu.hide();
     });
     
-    var defaultSize = $("li[data-default-size]", menu).attr("data-size");
-    var lastSize = lscache.get(cacheKey);
-    if (lastSize && menuItem(lastSize))
-      defaultSize = lastSize;
-    
-    menuItem(defaultSize).click();
+    Preferences.trigger("change:textSize");
   };
 });

--- a/js/friendlycode.js
+++ b/js/friendlycode.js
@@ -1,5 +1,6 @@
 define(function(require) {
   var $ = require("jquery"),
+      Preferences = require("fc/prefs"),
       TwoPanedEditor = require("fc/ui/two-paned-editor"),
       EditorToolbar = require("fc/ui/editor-toolbar"),
       Modals = require("fc/ui/modals"),
@@ -8,6 +9,8 @@ define(function(require) {
       Publisher = require("fc/publisher"),
       PublishUI = require("fc/ui/publish"),
       DefaultContentTemplate = require("template!default-content");
+
+  Preferences.fetch();
 
   return function FriendlycodeEditor(options) {
     var publishURL = options.publishURL,

--- a/test/index.html
+++ b/test/index.html
@@ -57,7 +57,8 @@
       "test/codemirror-577/test-codemirror-577",
       "test/preview-to-editor-mapping/test-preview-to-editor-mapping",
       "test/test-current-page-manager",
-      "test/test-editor-toolbar"
+      "test/test-editor-toolbar",
+      "test/test-prefs"
     ], function($) {
       var args = $.makeArray(arguments);
       args.slice(1).forEach(function(describeTests) {

--- a/test/test-prefs.js
+++ b/test/test-prefs.js
@@ -1,0 +1,52 @@
+defineTests(["fc/prefs", "lscache"], function(Preferences, lscache) {
+  Preferences.CACHE_KEY = "TestPreferences";
+
+  module("Preferences", {
+    setup: function() {
+      Preferences.off();
+      Preferences.clear();
+      Preferences.save();
+    }
+  });
+
+  test("is resilient when no stored value is available", function() {
+    lscache.remove(Preferences.CACHE_KEY);
+    Preferences.fetch();
+    equal(Preferences.get("blah"), undefined);
+  });
+
+  test("is resilient with corrupt JSON", function() {
+    lscache.set(Preferences.CACHE_KEY, "NO U!", 500);
+    Preferences.fetch();
+    equal(Preferences.get("blah"), undefined);
+  });
+  
+  test("loads stored preferences", function() {
+    lscache.set(Preferences.CACHE_KEY, {
+      meh: 1
+    }, 500);
+    Preferences.fetch();
+    equal(Preferences.get("meh"), 1);
+  });
+  
+  test("stores preferences", function() {
+    Preferences.set("blop", 5);
+    Preferences.save();
+    deepEqual(lscache.get(Preferences.CACHE_KEY), {
+      blop: 5
+    });
+  });
+  
+  test("can be destroyed", function() {
+    deepEqual(lscache.get(Preferences.CACHE_KEY), {});
+    Preferences.destroy();
+    equal(lscache.get(Preferences.CACHE_KEY), undefined);
+  });
+  
+  test("triggers change events", function() {
+    Preferences.on("change:foo", function() {
+      ok(true, "change:foo is triggered");
+    });
+    Preferences.set("foo", 1);
+  });
+});


### PR DESCRIPTION
This refactoring/enhancement uses [Backbone.Model](http://documentcloud.github.com/backbone/#Model) to store preferences. The model's `sync` method uses [lscache](https://github.com/pamelafox/lscache) for local storage.

The text-size dropdown has been changed to use this new mechanism for saving (it previously used lscache directly).

The "show hints" checkbox now uses this mechanism to persistently store its state (previously there was no state-saving across page loads, and the checkbox would always be checked on page load).

Among other things, this also makes our architecture more decoupled and MVC-like.
