### PR TITLE
Restore gutter pointer

### DIFF
--- a/css/errorhelp.css
+++ b/css/errorhelp.css
@@ -215,7 +215,6 @@ html .flipped .down-arrow {
 }
 
 svg.gutter-pointer {
-  position: absolute;
   z-index: 100;
 }
 

--- a/css/errorhelp.css
+++ b/css/errorhelp.css
@@ -213,3 +213,16 @@ html .flipped .down-arrow {
 .hint-marker-error {
   background-image: url("../img/explanationpt.png");
 }
+
+svg.gutter-pointer {
+  position: absolute;
+  z-index: 100;
+}
+
+svg.gutter-pointer.gutter-highlight-error polygon {
+  fill: #FF2A04;
+}
+
+svg.gutter-pointer.gutter-highlight-help polygon {
+  fill: #FF9933;
+}

--- a/css/jsbin-codemirror-theme.css
+++ b/css/jsbin-codemirror-theme.css
@@ -38,13 +38,13 @@
 
 .CodeMirror-gutter {
   background-color: #EEEEEE !important;
-  padding-right: 3px;
 }
 
 .CodeMirror-gutter-text {
   color: #A9A9A9;
   font-size: 12px;
   line-height: 15.75px;
+  padding-left: 0;
 }
 
 .cm-s-jsbin span.cm-meta {

--- a/js/fc/ui/gutter-pointer.js
+++ b/js/fc/ui/gutter-pointer.js
@@ -1,14 +1,46 @@
+"use strict";
+
+// gutterPointer(codeMirror, highlightClass)
+//
+// This function creates and returns an SVG shape that looks like this:
+//
+//   --\
+//   |  \
+//   |  /
+//   --/
+// 
+// It also puts the shape between the gutter and the content of a
+// CodeMirror line. The shape will be vertically stretched to take up the
+// entire height of the line.
+//
+// The shape is given the class gutter-pointer, as well as the same
+// class as the highlightClass argument.
+//
+// Arguments:
+// 
+//   codeMirror: The CodeMirror instance to apply the pointer to.
+//
+//   highlightClass: The class name used to "highlight" the desired
+//     gutter line via CodeMirror.setMarker().
+//
+// This function makes some assumptions about the way CodeMirror works,
+// as well as the styling applied to the CodeMirror instance, but we
+// try where possible to use methods and CSS classes documented in
+// the CodeMirror manual at http://codemirror.net/doc/manual.html.
+
 define(["jquery"], function($) {
-  return function gutterPointer(codeMirror, highlightClass) {
-    function attrs(element, attributes) {
-      for (var name in attributes)
-        element.setAttribute(name, attributes[name].toString());
-    }
-    
+  var SVG_NS = "http://www.w3.org/2000/svg";
+  
+  function attrs(element, attributes) {
+    for (var name in attributes)
+      element.setAttribute(name, attributes[name].toString());
+  }
+  
+  return function gutterPointer(codeMirror, highlightClass) {    
     var wrapper = $(codeMirror.getWrapperElement());
     var highlight = $(".CodeMirror-gutter-text ." + highlightClass, wrapper);
-    var SVG_NS = "http://www.w3.org/2000/svg";
     var svg = document.createElementNS(SVG_NS, "svg");
+    var pointer = document.createElementNS(SVG_NS, "polygon");
     var w = ($(".CodeMirror-gutter", wrapper).outerWidth() -
              highlight.width()) * 2;
     var h = highlight[0].getBoundingClientRect().height;
@@ -19,7 +51,6 @@ define(["jquery"], function($) {
       'class': "gutter-pointer " + highlightClass,
       viewBox: [0, 0, w, h].join(" ")
     });
-    var pointer = document.createElementNS(SVG_NS, "polygon");
     attrs(pointer, {
       points: [
         "0,0",
@@ -31,6 +62,7 @@ define(["jquery"], function($) {
     });
     svg.appendChild(pointer);
     $(svg).css({
+      position: 'absolute',
       width: w + "px",
       height: h + "px",
       top: pos.top + "px",

--- a/js/fc/ui/gutter-pointer.js
+++ b/js/fc/ui/gutter-pointer.js
@@ -1,0 +1,44 @@
+define(["jquery"], function($) {
+  return function gutterPointer(codeMirror, highlightClass) {
+    function attrs(element, attributes) {
+      for (var name in attributes)
+        element.setAttribute(name, attributes[name].toString());
+    }
+    
+    var wrapper = $(codeMirror.getWrapperElement());
+    var highlight = $(".CodeMirror-gutter-text ." + highlightClass, wrapper);
+    var SVG_NS = "http://www.w3.org/2000/svg";
+    var svg = document.createElementNS(SVG_NS, "svg");
+    var w = ($(".CodeMirror-gutter", wrapper).outerWidth() -
+             highlight.width()) * 2;
+    var h = highlight[0].getBoundingClientRect().height;
+    var pos = highlight.position();
+    
+    pos.left += highlight.width();
+    attrs(svg, {
+      'class': "gutter-pointer " + highlightClass,
+      viewBox: [0, 0, w, h].join(" ")
+    });
+    var pointer = document.createElementNS(SVG_NS, "polygon");
+    attrs(pointer, {
+      points: [
+        "0,0",
+        (w/2) + ",0",
+        w + "," + (h/2),
+        (w/2) + "," + h,
+        "0," + h
+      ].join(" ")
+    });
+    svg.appendChild(pointer);
+    $(svg).css({
+      width: w + "px",
+      height: h + "px",
+      top: pos.top + "px",
+      left: pos.left + "px"
+    });
+
+    $(".CodeMirror-scroll", wrapper).append(svg);
+    
+    return $(svg);
+  };
+});

--- a/js/fc/ui/relocator.js
+++ b/js/fc/ui/relocator.js
@@ -1,50 +1,7 @@
 "use strict";
 
 // code will relocate an error or help message to near where the error actually is in CodeMirror.
-define(["jquery"], function($) {
-  function makeGutterPointer(codeMirror, highlightClass) {
-    function attrs(element, attributes) {
-      for (var name in attributes)
-        element.setAttribute(name, attributes[name].toString());
-    }
-    
-    var wrapper = $(codeMirror.getWrapperElement());
-    var highlight = $(".CodeMirror-gutter-text ." + highlightClass, wrapper);
-    var SVG_NS = "http://www.w3.org/2000/svg";
-    var svg = document.createElementNS(SVG_NS, "svg");
-    var w = ($(".CodeMirror-gutter", wrapper).outerWidth() -
-             highlight.width()) * 2;
-    var h = highlight[0].getBoundingClientRect().height;
-    var pos = highlight.position();
-    
-    pos.left += highlight.width();
-    attrs(svg, {
-      'class': "gutter-pointer " + highlightClass,
-      viewBox: [0, 0, w, h].join(" ")
-    });
-    var pointer = document.createElementNS(SVG_NS, "polygon");
-    attrs(pointer, {
-      points: [
-        "0,0",
-        (w/2) + ",0",
-        w + "," + (h/2),
-        (w/2) + "," + h,
-        "0," + h
-      ].join(" ")
-    });
-    svg.appendChild(pointer);
-    $(svg).css({
-      width: w + "px",
-      height: h + "px",
-      top: pos.top + "px",
-      left: pos.left + "px"
-    });
-
-    $(".CodeMirror-scroll", wrapper).append(svg);
-    
-    return $(svg);
-  }
-  
+define(["jquery", "./gutter-pointer"], function($, gutterPointer) {
   return function Relocator(codeMirror) {
     var lastPos = null;
     var lastElement = null;
@@ -97,7 +54,7 @@ define(["jquery"], function($) {
         lastPos = codeMirror.posFromIndex(startMark);
         codeMirror.setLineClass(lastPos.line, null, "CodeMirror-line-highlight");
         codeMirror.setMarker(lastPos.line, null, highlightClass);
-        lastGutterPointer = makeGutterPointer(codeMirror, highlightClass);
+        lastGutterPointer = gutterPointer(codeMirror, highlightClass);
 
         codeMirror.addWidget(lastPos, lastElement[0], false);
         $(".up-arrow, .down-arrow", lastElement).css({

--- a/js/fc/ui/relocator.js
+++ b/js/fc/ui/relocator.js
@@ -2,9 +2,47 @@
 
 // code will relocate an error or help message to near where the error actually is in CodeMirror.
 define(["jquery"], function($) {
+  function makeGutterPointer(codeMirror, highlightClass) {
+    function attrs(element, attributes) {
+      for (var name in attributes)
+        element.setAttribute(name, attributes[name].toString());
+    }
+    
+    var wrapper = $(codeMirror.getWrapperElement());
+    var highlight = $(".CodeMirror-gutter-text ." + highlightClass, wrapper);
+    var SVG_NS = "http://www.w3.org/2000/svg";
+    var svg = document.createElementNS(SVG_NS, "svg");
+    var w = $(".CodeMirror-gutter", wrapper).outerWidth() -
+            highlight.width();
+    var h = highlight.height();
+    var pos = highlight.position();
+    
+    pos.left += highlight.width();
+    attrs(svg, {
+      'class': "gutter-pointer " + highlightClass,
+      viewBox: [0, 0, w, h].join(" ")
+    });
+    var pointer = document.createElementNS(SVG_NS, "polygon");
+    attrs(pointer, {
+      points: ["0,0", w + "," + (h/2), "0," + h].join(" ")
+    });
+    svg.appendChild(pointer);
+    $(svg).css({
+      width: w + "px",
+      height: h + "px",
+      top: pos.top + "px",
+      left: pos.left + "px"
+    });
+
+    $(".CodeMirror-scroll", wrapper).append(svg);
+    
+    return $(svg);
+  }
+  
   return function Relocator(codeMirror) {
     var lastPos = null;
     var lastElement = null;
+    var lastGutterPointer = null;
     var lastToggle = document.createElement("div");
 
     function flipElementIfNeeded() {
@@ -30,6 +68,10 @@ define(["jquery"], function($) {
           lastElement.hide();
           lastElement = null;
         }
+        if (lastGutterPointer) {
+          lastGutterPointer.remove();
+          lastGutterPointer = null;
+        }
         if (lastToggle.parentNode) {
           $(lastToggle).remove();
         }
@@ -37,6 +79,8 @@ define(["jquery"], function($) {
 
       // relocate an element to inside CodeMirror, pointing "at" the line for startMark
       relocate: function(element, startMark, type) {
+        var highlightClass = "gutter-highlight-" + type;
+
         this.cleanup();
         lastElement = $(element);
 
@@ -46,7 +90,8 @@ define(["jquery"], function($) {
         // the right one.
         lastPos = codeMirror.posFromIndex(startMark);
         codeMirror.setLineClass(lastPos.line, null, "CodeMirror-line-highlight");
-        codeMirror.setMarker(lastPos.line, null, "gutter-highlight-" + type);
+        codeMirror.setMarker(lastPos.line, null, highlightClass);
+        lastGutterPointer = makeGutterPointer(codeMirror, highlightClass);
 
         codeMirror.addWidget(lastPos, lastElement[0], false);
         $(".up-arrow, .down-arrow", lastElement).css({

--- a/js/fc/ui/relocator.js
+++ b/js/fc/ui/relocator.js
@@ -14,7 +14,7 @@ define(["jquery"], function($) {
     var svg = document.createElementNS(SVG_NS, "svg");
     var w = ($(".CodeMirror-gutter", wrapper).outerWidth() -
              highlight.width()) * 2;
-    var h = highlight.outerHeight();
+    var h = highlight[0].getBoundingClientRect().height;
     var pos = highlight.position();
     
     pos.left += highlight.width();

--- a/js/fc/ui/relocator.js
+++ b/js/fc/ui/relocator.js
@@ -12,9 +12,9 @@ define(["jquery"], function($) {
     var highlight = $(".CodeMirror-gutter-text ." + highlightClass, wrapper);
     var SVG_NS = "http://www.w3.org/2000/svg";
     var svg = document.createElementNS(SVG_NS, "svg");
-    var w = $(".CodeMirror-gutter", wrapper).outerWidth() -
-            highlight.width();
-    var h = highlight.height();
+    var w = ($(".CodeMirror-gutter", wrapper).outerWidth() -
+             highlight.width()) * 2;
+    var h = highlight.outerHeight();
     var pos = highlight.position();
     
     pos.left += highlight.width();
@@ -24,7 +24,13 @@ define(["jquery"], function($) {
     });
     var pointer = document.createElementNS(SVG_NS, "polygon");
     attrs(pointer, {
-      points: ["0,0", w + "," + (h/2), "0," + h].join(" ")
+      points: [
+        "0,0",
+        (w/2) + ",0",
+        w + "," + (h/2),
+        (w/2) + "," + h,
+        "0," + h
+      ].join(" ")
     });
     svg.appendChild(pointer);
     $(svg).css({

--- a/test/all-tests.js
+++ b/test/all-tests.js
@@ -12,5 +12,6 @@ defineTests.combine([
   "test/preview-to-editor-mapping/test-preview-to-editor-mapping",
   "test/test-current-page-manager",
   "test/test-editor-toolbar",
-  "test/test-prefs"
+  "test/test-prefs",
+  "test/test-gutter-pointer"
 ]);

--- a/test/test-gutter-pointer.js
+++ b/test/test-gutter-pointer.js
@@ -1,0 +1,24 @@
+defineTests([
+  "jquery",
+  "codemirror",
+  "fc/ui/gutter-pointer"
+], function($, CodeMirror, gutterPointer) {
+  module("gutterPointer");
+  
+  test("does not smoke", function() {
+    var div = $("<div></div>").appendTo("#qunit-fixture");
+    var cm = CodeMirror(div[0], {
+      value: "hello\nthere\ndude",
+      lineNumbers: true
+    });
+    
+    cm.setMarker(1, null, "blarg");
+    
+    var gp = gutterPointer(cm, "blarg");
+    equal(gp[0].nodeName, "svg", "gutterPointer is <svg>");
+    equal(gp[0].namespaceURI, "http://www.w3.org/2000/svg",
+          "gutterPointer has SVG namespace");
+    equal(gp.attr("class"), "gutter-pointer blarg");
+    div.remove();
+  });
+});

--- a/test/test-gutter-pointer.js
+++ b/test/test-gutter-pointer.js
@@ -15,6 +15,8 @@ defineTests([
     cm.setMarker(1, null, "blarg");
     
     var gp = gutterPointer(cm, "blarg");
+    equal(gp.css('position'), 'absolute',
+          'gutterPointer is absolutely positioned');
     equal(gp[0].nodeName, "svg", "gutterPointer is <svg>");
     equal(gp[0].namespaceURI, "http://www.w3.org/2000/svg",
           "gutterPointer has SVG namespace");


### PR DESCRIPTION
The gutter pointer is back!

Before 1c50dcc41d0b28123e8683072c58c5eeb02aebf2 we had a pointer, but it only worked on lines that didn't wrap, so we removed it (see mozilla/webpagemaker#335). The production branch currently looks like this now:

<img src="http://u.toolness.org/vljzt">

But this pull request contains an SVG-based one that looks like this for lines that don't wrap:

<img src="http://u.toolness.org/dwulk">

And this for lines that do wrap:

<img src="http://u.toolness.org/itqpm">

For reference, see Jess' original [gutter pointer mockup](http://www.flickr.com/photos/jessicaklein/7221327312).
