### PR TITLE
Allow Friendlycode embedders to provide alternate publisher backends and allow JS.

### DIFF
--- a/examples/alternate-publisher.html
+++ b/examples/alternate-publisher.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html class="deployment-type-development">
+  <head>
+    <meta charset="utf-8">
+    <base target="_blank">
+
+    <title>Alternate Publisher Friendlycode Editor</title>
+    <link rel="stylesheet" href="../css/friendlycode.css">
+  </head>
+  <body style="margin: 0">
+    <div id="bare-fc-holder" class="friendlycode-loading"></div>
+
+    <script src="../js/require-config.js"></script>
+    <script src="../js/require.min.js"></script>
+    <script>
+    // Alternate publisher implementation that publishes to a hackpub
+    // endpoint. For more information, see:
+    // 
+    //   https://github.com/hackasaurus/hackpub
+    //
+    // Note also that the Amazon S3 bucket hackpub publishes to must
+    // be configured with a CORS configuration that allows for cross-origin
+    // GET requests, e.g.:
+    //
+    //   <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    //     <CORSRule>
+    //       <AllowedOrigin>*</AllowedOrigin>
+    //       <AllowedMethod>GET</AllowedMethod>
+    //     </CORSRule>
+    //   </CORSConfiguration>
+     
+    define("hackpub", ["jquery"], function($) {
+      return function Hackpub(options) {
+        return {
+          loadCode: function(path, cb) {
+            var url = options.publishURL + path;
+            $.ajax({
+              type: "GET",
+              url: url,
+              dataType: 'text',
+              error: function(req) {
+                cb(req);
+              },
+              success: function(html) {
+                cb(null, html, url);
+              }
+            });
+          },
+          saveCode: function(data, originalURL, cb) {
+            $.ajax({
+              type: "POST",
+              url: options.hackpubURL + "/publish",
+              data: {
+                'html': data,
+                'original-url': originalURL
+              },
+              dataType: 'json',
+              error: function(req) {
+                cb(req);
+              },
+              success: function(result) {
+                var url = result['published-url'];
+                var path = '/' + url.match(/\/([A-Za-z0-9]+)$/)[1];
+                cb(null, {path: path, url: options.publishURL + path});
+              }
+            });
+          }
+        };
+      };
+    });
+    </script>
+    <script>
+    require([
+      "jquery",
+      "friendlycode",
+      "hackpub"
+    ], function($, FriendlycodeEditor, Hackpub) {
+      return FriendlycodeEditor({
+        allowJS: true,
+        publisher: Hackpub({
+          hackpubURL: "http://hackpub.hackasaurus.org",
+          publishURL: "http://poof.hksr.us"
+        }),
+        container: $("#bare-fc-holder")
+      });
+    });
+    </script>
+  </body>
+</html>

--- a/js/fc/ui/editor-panes.js
+++ b/js/fc/ui/editor-panes.js
@@ -19,6 +19,7 @@ define(function(require) {
     var self = {},
         div = options.container,
         initialValue = options.value || "",
+        allowJS = options.allowJS || false,
         sourceCode = $('<div class="source-code"></div>').appendTo(div),
         previewArea = $('<div class="preview-holder"></div>').appendTo(div),
         helpArea = $('<div class="help hidden"></div>').appendTo(div),
@@ -32,7 +33,8 @@ define(function(require) {
       lineNumbers: true,
       value: initialValue,
       parse: function(html) {
-        return Slowparse.HTML(document, html, [TreeInspectors.forbidJS]);
+        return Slowparse.HTML(document, html,
+                              allowJS ? [] : [TreeInspectors.forbidJS]);
       }
     });
     var relocator = Relocator(codeMirror);

--- a/js/fc/ui/editor.js
+++ b/js/fc/ui/editor.js
@@ -14,7 +14,8 @@ define([
     
     var panes = EditorPanes({
       container: panesDiv,
-      value: value
+      value: value,
+      allowJS: options.allowJS
     });
     var toolbar = EditorToolbar({
       container: toolbarDiv,

--- a/js/friendlycode.js
+++ b/js/friendlycode.js
@@ -25,7 +25,7 @@ define(function(require) {
       container: $('<div class="friendlycode-base"></div>')
         .appendTo(document.body)
     });
-    var publisher = Publisher(publishURL);
+    var publisher = options.publisher || Publisher(publishURL);
     var publishUI = PublishUI({
       modals: modals,
       codeMirror: editor.panes.codeMirror,

--- a/js/friendlycode.js
+++ b/js/friendlycode.js
@@ -18,7 +18,10 @@ define(function(require) {
         remixURLTemplate = options.remixURLTemplate ||
           location.protocol + "//" + location.host + 
           location.pathname + "#{{VIEW_URL}}",
-        editor = Editor({container: options.container}),
+        editor = Editor({
+          container: options.container,
+          allowJS: options.allowJS
+        }),
         ready = $.Deferred();
     
     var modals = Modals({


### PR DESCRIPTION
This will allow us to have an experimental JS-enabled Thimble for MozFest.
