### PR TITLE
Remove borders from .thimble-url-box

### DIFF
--- a/css/modals.css
+++ b/css/modals.css
@@ -148,8 +148,6 @@
 
 .thimble-url-box {
   background-color: #FFFFFF;
-  border: 1px solid #A0A0A0;
-  border-radius: 5px 5px 5px 5px;
   color: blue;
   height: 25px;
   margin: 10px auto 1em;

--- a/css/modals_full_screen.css
+++ b/css/modals_full_screen.css
@@ -52,10 +52,8 @@
 .thimble-url-box {
   background-color: #FFFFFF;
   color: blue;
-  border: 1px solid #C0C0C0;
   height: 30px;
   width: 350px;
-  border-radius: 10px;
   padding-top: 10px;
   padding-left: 1em;
   margin: 1em 0px;


### PR DESCRIPTION
I'm not 100% sure what `modals_full_screen.css` is used for, but assumed it should be the same there?

Closes #140.
