### PR TITLE
Adding dimple

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -464,7 +464,7 @@ div.editor-actions {
   font-size: 12px;
 }
 
-.breadcrumbs {
+.friendlycode-base .breadcrumbs {
   position: relative;
   display: inline-block;
   width: 1px;
@@ -472,8 +472,8 @@ div.editor-actions {
   margin: 0;
   border-right: 1px solid #d6d8d7;
 }
-.breadcrumbs:after,
-.breadcrumbs:before {
+.friendlycode-base .breadcrumbs:after,
+.friendlycode-base .breadcrumbs:before {
   left: 100%;
   border: solid transparent;
   content: " ";
@@ -482,13 +482,13 @@ div.editor-actions {
   position: absolute;
   pointer-events: none;
 }
-.breadcrumbs:after {
+.friendlycode-base .breadcrumbs:after {
   border-left-color: #fff; 
   border-width: 5px;
   top: 50%;
   margin-top: -5px;
 }
-.breadcrumbs:before {
+.friendlycode-base .breadcrumbs:before {
   border-left-color: #d6d8d7;
   border-width: 7px;
   top: 50%;

--- a/css/editor.css
+++ b/css/editor.css
@@ -463,3 +463,34 @@ div.editor-actions {
   /* Make tipsy tooltips slightly larger than the default. */
   font-size: 12px;
 }
+
+.breadcrumbs {
+  position: relative;
+  display: inline-block;
+  width: 1px;
+  height: 100%;
+  margin: 0;
+  border-right: 1px solid #d6d8d7;
+}
+.breadcrumbs:after,
+.breadcrumbs:before {
+  left: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.breadcrumbs:after {
+  border-left-color: #fff; 
+  border-width: 5px;
+  top: 50%;
+  margin-top: -5px;
+}
+.breadcrumbs:before {
+  border-left-color: #d6d8d7;
+  border-width: 7px;
+  top: 50%;
+  margin-top: -7px;
+}

--- a/templates/nav-options.html
+++ b/templates/nav-options.html
@@ -5,6 +5,7 @@
       <span class="icon">&nbsp;</span>Editor
       <div class="pane-indicator enabled"></div>
     </div>
+    <div class="nav-item"><div class="breadcrumbs"></div></div>
     <div class="undo-nav-item nav-item responsive"
          data-restore-help="We've rescued your very recent changes to this page, but you can click this button to undo them."
          title="Undo changes">


### PR DESCRIPTION
Closes #145.

Adds a dimple next to Editor. Uses similar css to webpagemaker, but namespaced to .friendlycode-base to be able to override those styles.
