### PR TITLE
attempt to fix #176 by unescaping XML in key values from transifex.

### DIFF
--- a/bin/transifex.js
+++ b/bin/transifex.js
@@ -47,9 +47,18 @@ var toBundleDict = exports.toBundleDict = function(options) {
   options.strings.forEach(function(info) {
     if (!info.translation) return;
     if (options.reviewedOnly && !info.reviewed) return;
-    dict[info.key] = info.translation;
+    // We're unescaping info.key due to what appears to be a strange
+    // Transifex bug: https://github.com/mozilla/friendlycode/issues/176
+    dict[unescapeXML(info.key)] = info.translation;
   });
   return dict;
+};
+
+var unescapeXML = exports.unescapeXML = function(str) {
+  return str.replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"');
 };
 
 function importFromTransifex(options) {

--- a/test/node-tap/test-transifex.js
+++ b/test/node-tap/test-transifex.js
@@ -23,10 +23,14 @@ var translationsForACollectionOfStrings = [
   {
     "comment": "This string appears in https://github.com/mozilla/blah.",
     "context": "",
-    "key": "Are you sure you want to publish your page?",
+    // Yes, Transifex doesn't seem to unescape &amp; on its own, and
+    // chooses instead to interpret the content of <key> elements in the
+    // PLIST file as though it's CDATA. For more information, see
+    // https://github.com/mozilla/friendlycode/issues/176.
+    "key": "Are you sure you want to publish your page &amp; stuff?",
     "reviewed": false,
     "pluralized": false,
-    "source_string": "Are you sure you want to publish your page?",
+    "source_string": "Are you sure you want to publish your page & stuff?",
     "translation": "blargyblarg?"
   },
   {
@@ -184,12 +188,20 @@ test("toBundleDict({reviewedOnly: true}) works", function(t) {
   t.end();
 });
 
+test("unescapeXML() works", function(t) {
+  t.equal(transifex.unescapeXML("blah&quot;u"), 'blah"u');
+  t.equal(transifex.unescapeXML("blah &gt; u"), 'blah > u');
+  t.equal(transifex.unescapeXML("&lt;3"), '<3');
+  t.equal(transifex.unescapeXML("&amp;hellip;"), '&hellip;');
+  t.end();
+});
+
 test("toBundleDict({reviewedOnly: false}) works", function(t) {
   t.deepEqual(transifex.toBundleDict({
     strings: translationsForACollectionOfStrings,
     reviewedOnly: false
   }), {
-    "Are you sure you want to publish your page?": "blargyblarg?",
+    "Are you sure you want to publish your page & stuff?": "blargyblarg?",
     "error-warning": "<strong>Achtung!</strong>"
   });
   t.end();


### PR DESCRIPTION
I'm not a huge fan of this solution because if transifex ever starts unescaping key values itself, we won't really know ... and it's hard to write integration tests w/ transifex because accessing the translations of an open-source project using their API still requires username/password authentication.
