### PR TITLE
adds a "dismiss" link to the lower-right of the error/help dialogs

### DIFF
--- a/css/errorhelp.css
+++ b/css/errorhelp.css
@@ -190,6 +190,25 @@ html .flipped .down-arrow {
   background-image: url("../img/hint-up-arrow.png");
 }
 
+.error .dismiss,
+.help .dismiss {
+  position: absolute;
+  display: inline-block;
+  right: 0;
+  bottom: 0;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.error .dismiss {
+  color: #FF2A04;
+}
+
+.help .dismiss {
+  color: #FF9933;
+}
+
+
 .hint-marker-positioning {
   left: auto !important; /* CodeMirror will set this value, but we don't want it set! */
   right: 1em;

--- a/js/fc/ui/context-sensitive-help.js
+++ b/js/fc/ui/context-sensitive-help.js
@@ -27,7 +27,7 @@ define([
       relocator.cleanup();
     }
 
-    // The escape key should close hints 
+    // The escape key should close hints
     $(document).keyup(function(event) {
       if (event.keyCode == 27)
         clearHelp();
@@ -43,7 +43,7 @@ define([
       if (!event.error)
         helpIndex.build(event.document, event.sourceCode);
     });
-    
+
     function showHelp(cursorIndex, help) {
       cursorHelpMarks.clear();
 
@@ -76,17 +76,17 @@ define([
           helpArea.fadeIn();
         }
       }
-      // clicking the dismiss link should also close error help 
+      // clicking the dismiss link should also close error help
       var dismiss = helpArea.find(".dismiss");
       if(dismiss) {
         dismiss.click(clearHelp);
-      }      
+      }
     }
-   
+
     codeMirror.on("change", clearHelp);
     codeMirror.on("cursor-activity", function() {
       clearTimeout(timeout);
-      
+
       if (Preferences.get("showHints") === false)
         return;
 
@@ -116,7 +116,7 @@ define([
       if (Preferences.get("showHints") === false)
         clearHelp();
     });
-    
+
     Preferences.trigger("change:showHints");
     return self;
   };

--- a/js/fc/ui/context-sensitive-help.js
+++ b/js/fc/ui/context-sensitive-help.js
@@ -18,7 +18,15 @@ define([
     var timeout = null;
     var lastHelp = null;
     var HELP_DISPLAY_DELAY = 250;
-    
+
+    function clearHelp() {
+      clearTimeout(timeout);
+      lastHelp = null;
+      cursorHelpMarks.clear();
+      helpArea.hide();
+      relocator.cleanup();
+    }
+
     // The escape key should close hints 
     $(document).keyup(function(event) {
       if (event.keyCode == 27)
@@ -68,16 +76,13 @@ define([
           helpArea.fadeIn();
         }
       }
+      // clicking the dismiss link should also close error help 
+      var dismiss = helpArea.find(".dismiss");
+      if(dismiss) {
+        dismiss.click(clearHelp);
+      }      
     }
-
-    function clearHelp() {
-      clearTimeout(timeout);
-      lastHelp = null;
-      cursorHelpMarks.clear();
-      helpArea.hide();
-      relocator.cleanup();
-    }
-    
+   
     codeMirror.on("change", clearHelp);
     codeMirror.on("cursor-activity", function() {
       clearTimeout(timeout);

--- a/js/fc/ui/error-help.js
+++ b/js/fc/ui/error-help.js
@@ -39,7 +39,7 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
       relocator.cleanup();
     }
 
-    // The escape key should close error help 
+    // The escape key should close error help
     $(document).keyup(function(event) {
       if (event.keyCode == 27)
         clearError();
@@ -47,12 +47,12 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
 
     // Keep track of error highlighting.
     var errorHelpMarks = MarkTracker(codeMirror, relocator);
-  
+
     // Report the given Slowparse error.
     function reportError(error) {
       var startMark = null;
       var errorHTML = $("<div></div>").fillError(error);
-      errorArea.html(template({error: errorHTML.html()})).show();         
+      errorArea.html(template({error: errorHTML.html()})).show();
       errorArea.eachErrorHighlight(function(start, end, i) {
         // Point the error message's arrow at the first occurrence of
         // the word "here" in the error message.
@@ -67,7 +67,7 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
       });
       relocator.relocate(errorArea, startMark, "error");
 
-      // clicking the dismiss link should also close error help 
+      // clicking the dismiss link should also close error help
       var dismiss = errorArea.find(".dismiss");
       if(dismiss) {
         dismiss.click(clearError);
@@ -75,7 +75,7 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
 
       errorArea.hide();
     }
-     
+
     codeMirror.on("change", clearError);
     codeMirror.on("reparse", function(event) {
       clearError();

--- a/js/fc/ui/error-help.js
+++ b/js/fc/ui/error-help.js
@@ -31,6 +31,14 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
     var timeout = null;
     var ERROR_DISPLAY_DELAY = 250;
 
+    // remove the error help from view
+    function clearError() {
+      clearTimeout(timeout);
+      errorHelpMarks.clear();
+      errorArea.hide();
+      relocator.cleanup();
+    }
+
     // The escape key should close error help 
     $(document).keyup(function(event) {
       if (event.keyCode == 27)
@@ -44,7 +52,7 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
     function reportError(error) {
       var startMark = null;
       var errorHTML = $("<div></div>").fillError(error);
-      errorArea.html(template({error: errorHTML.html()})).show();
+      errorArea.html(template({error: errorHTML.html()})).show();         
       errorArea.eachErrorHighlight(function(start, end, i) {
         // Point the error message's arrow at the first occurrence of
         // the word "here" in the error message.
@@ -58,16 +66,16 @@ define(["jquery-slowparse", "./mark-tracker"], function($, MarkTracker) {
         });
       });
       relocator.relocate(errorArea, startMark, "error");
+
+      // clicking the dismiss link should also close error help 
+      var dismiss = errorArea.find(".dismiss");
+      if(dismiss) {
+        dismiss.click(clearError);
+      }
+
       errorArea.hide();
     }
-  
-    function clearError() {
-      clearTimeout(timeout);
-      errorHelpMarks.clear();
-      errorArea.hide();
-      relocator.cleanup();
-    }
-    
+     
     codeMirror.on("change", clearError);
     codeMirror.on("reparse", function(event) {
       clearError();

--- a/templates/error-msg.html
+++ b/templates/error-msg.html
@@ -3,5 +3,5 @@
 <div class="content">
   <%= error %>
 </div>
-<div class="dismiss"> L10N[[[dismiss]]]</div>
+<div class="dismiss">L10N[[[dismiss]]]</div>
 <div class="down-arrow"></div>

--- a/templates/error-msg.html
+++ b/templates/error-msg.html
@@ -3,4 +3,5 @@
 <div class="content">
   <%= error %>
 </div>
+<div class="dismiss">dismiss</div>
 <div class="down-arrow"></div>

--- a/templates/error-msg.html
+++ b/templates/error-msg.html
@@ -3,5 +3,5 @@
 <div class="content">
   <%= error %>
 </div>
-<div class="dismiss">dismiss</div>
+<div class="dismiss"> L10N[[[dismiss]]]</div>
 <div class="down-arrow"></div>

--- a/templates/help-msg.html
+++ b/templates/help-msg.html
@@ -7,5 +7,5 @@
   <% } %>
   <a class="learn-more" href="<%- url %>">L10N[[[more…]]]</a>
 </div>
-<div class="dismiss"> L10N[[[dismiss]]]</div>
+<div class="dismiss">L10N[[[dismiss]]]</div>
 <div class="down-arrow"></div>

--- a/templates/help-msg.html
+++ b/templates/help-msg.html
@@ -7,4 +7,5 @@
   <% } %>
   <a class="learn-more" href="<%- url %>">L10N[[[more…]]]</a>
 </div>
+<div class="dismiss">dismiss</div>
 <div class="down-arrow"></div>

--- a/templates/help-msg.html
+++ b/templates/help-msg.html
@@ -7,5 +7,5 @@
   <% } %>
   <a class="learn-more" href="<%- url %>">L10N[[[more…]]]</a>
 </div>
-<div class="dismiss">dismiss</div>
+<div class="dismiss"> L10N[[[dismiss]]]</div>
 <div class="down-arrow"></div>


### PR DESCRIPTION
we had multiple bug reports that the error/help dialog could not be closed under certain circumstances, due to it covering the error or being otherwise inconveniently placed. This pull request adds an in-dialog  "dismiss" link that hides the error/help dialog again, so that people can always close it, without needing to click anywhere outside the dialog.
